### PR TITLE
Forecast refactor

### DIFF
--- a/facades/forecast.js
+++ b/facades/forecast.js
@@ -3,28 +3,28 @@ var GeocodeService = require('../services/geocode');
 var ForecastService = require('../services/forecast');
 
 module.exports = class ForecastFacade {
+  /* Facade object contains the status and body of the response,
+     which is initialized in the static method for the endpoint */
   constructor(status, body) {
     this.status = status
     this.body = body
   }
 
   static forecastForUser(api_key, location) {
-    console.log(location);
     return new Promise((resolve, reject) => {
       User.authenticate(api_key)
       .then(function() {
         return GeocodeService.requestLocation(location)
       })
       .then(function(location) {
-        console.log(location);
         return ForecastService.requestForecast(location)
       })
       .then(function(forecast) {
         delete forecast.minutely;
-        resolve(new ForecastFacade(200, forecast));
+        resolve(new ForecastFacade(200, forecast)); // Got valid forecast, send 200
       })
       .catch(error => {
-        resolve(new ForecastFacade(401, error));
+        resolve(new ForecastFacade(401, error)); // Bad request, send 401 and error
       })
     })
   }

--- a/facades/forecast.js
+++ b/facades/forecast.js
@@ -1,0 +1,31 @@
+var User = require('../models').User;
+var GeocodeService = require('../services/geocode');
+var ForecastService = require('../services/forecast');
+
+module.exports = class ForecastFacade {
+  constructor(status, body) {
+    this.status = status
+    this.body = body
+  }
+
+  static forecastForUser(api_key, location) {
+    console.log(location);
+    return new Promise((resolve, reject) => {
+      User.authenticate(api_key)
+      .then(function() {
+        return GeocodeService.requestLocation(location)
+      })
+      .then(function(location) {
+        console.log(location);
+        return ForecastService.requestForecast(location)
+      })
+      .then(function(forecast) {
+        delete forecast.minutely;
+        resolve(new ForecastFacade(200, forecast));
+      })
+      .catch(error => {
+        resolve(new ForecastFacade(401, error));
+      })
+    })
+  }
+}

--- a/models/user.js
+++ b/models/user.js
@@ -20,5 +20,19 @@ module.exports = (sequelize, DataTypes) => {
       as: 'locations'
    });
   };
+
+  User.authenticate = function(api_key) {
+    return new Promise((resolve, reject) => {
+      User.findOne({
+        where: {
+          api_key: api_key
+        }
+      })
+      .then(user => {
+        user ? resolve(user) : reject({error: "Invalid API Key"})
+      })
+      .catch(error => reject(error))
+    })
+  }
   return User;
 };

--- a/models/user.js
+++ b/models/user.js
@@ -29,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
         }
       })
       .then(user => {
-        user ? resolve(user) : reject({"Invalid API Key"})
+        user ? resolve(user) : reject("Invalid API Key")
       })
       .catch(error => reject(error))
     })

--- a/models/user.js
+++ b/models/user.js
@@ -29,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
         }
       })
       .then(user => {
-        user ? resolve(user) : reject({error: "Invalid API Key"})
+        user ? resolve(user) : reject({"Invalid API Key"})
       })
       .catch(error => reject(error))
     })

--- a/models/user.js
+++ b/models/user.js
@@ -29,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
         }
       })
       .then(user => {
-        user ? resolve(user) : reject("Invalid API Key")
+        user ? resolve(user) : reject({error: "Invalid API Key"})
       })
       .catch(error => reject(error))
     })

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -1,27 +1,13 @@
 var express = require('express');
 var router = express.Router();
-var User = require('../../../models').User;
-var GeocodeService = require('../../../services/geocode');
-var ForecastService = require('../../../services/forecast');
-require('dotenv').config(); // Loads environment variables from .env file
+var ForecastFacade = require('../../../facades/forecast');
 
 /* GET forecast for a city */
 router.get('/', function(req, res) {
-  User.authenticate(req.body.api_key)
-  .then(function() {
-    return GeocodeService.requestLocation(req.query.location)
-  })
-  .then(function(location) {
-    return ForecastService.requestForecast(location)
-  })
-  .then(function(forecast) {
-    delete forecast.minutely;
+  ForecastFacade.forecastForUser(req.body.api_key, req.query.location)
+  .then(forecast => {
     res.setHeader("Content-Type", "application/json");
-    res.status(200).send(JSON.stringify(forecast));
-  })
-  .catch(error => {
-    res.setHeader("Content-Type", "application/json");
-    res.status(401).send(JSON.stringify({error: error}))
+    res.status(forecast.status).send(forecast.body);
   })
 })
 

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -7,16 +7,7 @@ require('dotenv').config(); // Loads environment variables from .env file
 
 /* GET forecast for a city */
 router.get('/', function(req, res) {
-  User.findOne({
-    where: {
-      api_key: req.body.api_key
-    }
-  })
-  .then(user => {
-    return new Promise((resolve, reject) => {
-      user ? resolve(user) : reject("Invalid API Key")
-    })
-  })
+  User.authenticate(req.body.api_key)
   .then(function() {
     return GeocodeService.requestLocation(req.query.location)
   })

--- a/services/forecast.js
+++ b/services/forecast.js
@@ -1,4 +1,6 @@
 var fetch = require('node-fetch');
+require('dotenv').config(); // Loads environment variables from .env file
+
 
 module.exports = class ForecastService {
   static requestForecast(location) {

--- a/services/forecast.js
+++ b/services/forecast.js
@@ -1,0 +1,12 @@
+var fetch = require('node-fetch');
+
+module.exports = class ForecastService {
+  static requestForecast(location) {
+    return new Promise((resolve, reject) => {
+      fetch(`https://api.darksky.net/forecast/${process.env.DARKSKY_KEY}/${location.lat},${location.lng}`)
+      .then(response => response.json())
+      .then(result => resolve(result))
+      .catch(error => reject(error))
+    })
+  }
+}

--- a/services/geocode.js
+++ b/services/geocode.js
@@ -1,4 +1,6 @@
 var fetch = require('node-fetch');
+require('dotenv').config(); // Loads environment variables from .env file
+
 
 module.exports = class GeocodeService {
   static requestLocation(location) {

--- a/services/geocode.js
+++ b/services/geocode.js
@@ -1,0 +1,12 @@
+var fetch = require('node-fetch');
+
+module.exports = class GeocodeService {
+  static requestLocation(location) {
+    return new Promise((resolve, reject) => {
+      fetch(`https://maps.googleapis.com/maps/api/geocode/json?key=${process.env.GOOGLE_GEOCODE_KEY}&address=${location}`)
+      .then(response => response.json())
+      .then(result => resolve(result.results[0].geometry.location))
+      .catch(error => reject(error))
+    })
+  }
+}


### PR DESCRIPTION
- Adds service classes for geocoding and forecast request to remove code from route.
- Moves services off HTTPS library and on to node-fetch
- Adds facade for forecast endpoint to further reduce code present in route.
- Adds authenticate method to user model for verifying users via API key.

@aprildagonese could you please take a look at these refactors and let me know if you see any place that I could further refactor the forecast endpoint? Additionally, if you see any places where I may have missed an edge case or could use some better documentation.