### PR TITLE
Forecast endpoint location refactor

### DIFF
--- a/facades/favorites_create.js
+++ b/facades/favorites_create.js
@@ -1,5 +1,4 @@
 var User = require('../models').User;
-// var Location = require('../models').Location;
 var Favorite = require('../models').Favorite;
 var GeocodeService = require('../services/geocode');
 var LocationHelper = require('../helpers/location');

--- a/facades/favorites_create.js
+++ b/facades/favorites_create.js
@@ -1,7 +1,8 @@
 var User = require('../models').User;
-var Location = require('../models').Location;
+// var Location = require('../models').Location;
 var Favorite = require('../models').Favorite;
 var GeocodeService = require('../services/geocode');
+var LocationHelper = require('../helpers/location');
 
 module.exports = class FavoritesCreateFacade {
   constructor(status, body) {
@@ -18,7 +19,7 @@ module.exports = class FavoritesCreateFacade {
       })
       .then(user => {
         foundUser = user;
-        return findOrCreateCity(location);
+        return LocationHelper.findOrCreateCity(location);
       })
       .then(location => {
         locationName = location.name
@@ -45,35 +46,5 @@ function verifyNotFavorite(user, location) {
     location ?
     reject({error: location + " is already favorited"}) :
     resolve(user)
-  })
-}
-
-function findOrCreateCity(location) {
-  return new Promise((resolve, reject) => {
-    Location.findOne({
-      where: {
-        name: location
-      }
-    })
-    .then(function(foundLocation) {
-      if (foundLocation) {
-        resolve(foundLocation);
-      } else {
-        return GeocodeService.requestLocation(location)
-      }
-    })
-    .then(response => {
-      return Location.create({
-        name: location,
-        latitude: response.lat,
-        longitude: response.lng
-      })
-    })
-    .then(function(location) {
-      resolve(location)
-    })
-    .catch(function(error) {
-      reject()
-    })
   })
 }

--- a/facades/forecast.js
+++ b/facades/forecast.js
@@ -1,6 +1,7 @@
 var User = require('../models').User;
 var GeocodeService = require('../services/geocode');
 var ForecastService = require('../services/forecast');
+var LocationHelper = require('../helpers/location');
 
 module.exports = class ForecastFacade {
   /* Facade object contains the status and body of the response,
@@ -14,7 +15,7 @@ module.exports = class ForecastFacade {
     return new Promise((resolve, reject) => {
       User.authorize(api_key)
       .then(function() {
-        return GeocodeService.requestLocation(location)
+        return LocationHelper.findOrCreateCity(location)
       })
       .then(function(location) {
         return ForecastService.requestForecast(location)

--- a/helpers/location.js
+++ b/helpers/location.js
@@ -1,0 +1,34 @@
+var Location = require('../models').Location;
+var GeocodeService = require('../services/geocode');
+
+module.exports = class LocationHelper {
+  static findOrCreateCity(location) {
+    return new Promise((resolve, reject) => {
+      Location.findOne({
+        where: {
+          name: location
+        }
+      })
+      .then(function(foundLocation) {
+        if (foundLocation) {
+          resolve(foundLocation);
+        } else {
+          return GeocodeService.requestLocation(location)
+        }
+      })
+      .then(response => {
+        return Location.create({
+          name: location,
+          latitude: response.lat,
+          longitude: response.lng
+        })
+      })
+      .then(function(location) {
+        resolve(location)
+      })
+      .catch(function(error) {
+        reject()
+      })
+    })
+  }
+}

--- a/services/forecast.js
+++ b/services/forecast.js
@@ -5,7 +5,7 @@ require('dotenv').config(); // Loads environment variables from .env file
 module.exports = class ForecastService {
   static requestForecast(location) {
     return new Promise((resolve, reject) => {
-      fetch(`https://api.darksky.net/forecast/${process.env.DARKSKY_KEY}/${location.lat},${location.lng}`)
+      fetch(`https://api.darksky.net/forecast/${process.env.DARKSKY_KEY}/${location.latitude},${location.longitude}`)
       .then(response => response.json())
       .then(result => resolve(result))
       .catch(error => reject(error))


### PR DESCRIPTION
- Adds location helper to handle looking up location records in the database or requesting new geocoding information for nonexistent locations.
- Updates favorite_create and forecast facades to use location_helper
- Updates location service to use location model information for requests instead of previous geocoding format.